### PR TITLE
TECH-7484 add default perms to pipeline

### DIFF
--- a/sourcedive/settings.py
+++ b/sourcedive/settings.py
@@ -141,6 +141,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.social_auth.load_extra_data',
     'social_core.pipeline.user.user_details',
+    'sources.pipeline.add_permissions_to_new_whitelisted_users',
 )
 
 LOCALE_PATHS = [os.path.join(BASE_DIR, 'locale/')]

--- a/sourcedive/settings_private.dev.py
+++ b/sourcedive/settings_private.dev.py
@@ -1,0 +1,46 @@
+## private settings
+
+SECRET_KEY = ''  # UPDATE with random string
+
+ALLOWED_HOSTS = [
+    # local
+    'localhost',
+    '127.0.0.1',
+    # staging
+    '35.232.16.182',
+]
+INTERNAL_IPS = ['127.0.0.1']
+
+## for local and test servers
+TEST_ENV = True
+## for prod server
+# TEST_ENV = False
+
+## project info
+
+PROJECT_NAME = 'SourceDive'
+
+## database staging
+# db_engine = 'django.db.backends.postgresql_psycopg2'
+# db_name = ''  # UPDATE see lastpass
+# db_user = ''  # UPDATE see lastpass
+# db_password = ''  # UPDATE see lastpass
+# db_host = 'localhost'
+# db_port = ''
+
+## database local
+db_engine = 'django.db.backends.postgresql_psycopg2'
+db_name = ''  # UPDATE see lastpass
+db_user = ''  # UPDATE see lastpass
+db_password = ''  # UPDATE see lastpass
+db_host = 'localhost'
+db_port = ''
+
+## social auth
+SOCIAL_AUTH_PASSWORDLESS = True
+SOCIAL_AUTH_ALWAYS_ASSOCIATE = True
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = ''  # UPDATE see lastpass
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = ''  # UPDATE see lastpass
+
+SOCIAL_AUTH_GOOGLE_WHITELISTED_DOMAINS = ['industrydive.com']

--- a/sources/pipeline.py
+++ b/sources/pipeline.py
@@ -1,0 +1,37 @@
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+
+from sources.models import Expertise, Industry, Interaction, Organization, Source
+
+
+def add_permissions_to_new_whitelisted_users(backend, user, response, *args, **kwargs):
+    if not user.last_login:
+        user.is_staff = True
+
+        try:
+            # get the group
+            group = Group.objects.get(name='Newsroom user')
+            # add the user to that group
+            group.user_set.add(user)
+            user.save()
+        except ObjectDoesNotExist:
+            pass
+        # group, created_now = Group.objects.get_or_create(name='Newsroom user')
+        # if created_now:
+        #     a = ContentType.objects.get_for_model()
+        #     b = etc etc 
+        """     can we abstract this? e.g. use this for model names
+                    from django.apps import apps
+
+                    Model = apps.get_model('app_name', 'model_name')
+                and then add them to an iterable so we can loop thru?
+        """
+        #     # add the permissions objects to the group
+        #     permission = Permission.objects.create(
+        #         codename='can_add_project',
+        #         name='Can add project',
+        #         content_type=ct
+        #     )
+        #     new_group.permissions.add(permission)
+

--- a/sources/pipeline.py
+++ b/sources/pipeline.py
@@ -14,24 +14,7 @@ def add_permissions_to_new_whitelisted_users(backend, user, response, *args, **k
             group = Group.objects.get(name='Newsroom user')
             # add the user to that group
             group.user_set.add(user)
-            user.save()
         except ObjectDoesNotExist:
             pass
-        # group, created_now = Group.objects.get_or_create(name='Newsroom user')
-        # if created_now:
-        #     a = ContentType.objects.get_for_model()
-        #     b = etc etc 
-        """     can we abstract this? e.g. use this for model names
-                    from django.apps import apps
-
-                    Model = apps.get_model('app_name', 'model_name')
-                and then add them to an iterable so we can loop thru?
-        """
-        #     # add the permissions objects to the group
-        #     permission = Permission.objects.create(
-        #         codename='can_add_project',
-        #         name='Can add project',
-        #         content_type=ct
-        #     )
-        #     new_group.permissions.add(permission)
-
+        # goes outside try/except bc needed for user.is_staff
+        user.save()

--- a/sources/pipeline.py
+++ b/sources/pipeline.py
@@ -1,8 +1,6 @@
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
-
-from sources.models import Expertise, Industry, Interaction, Organization, Source
 
 
 def add_permissions_to_new_whitelisted_users(backend, user, response, *args, **kwargs):


### PR DESCRIPTION
https://industrydive.atlassian.net/browse/TECH-7484

**Goal**
Because we've whitelisted the `industrydive.com` domain with the Django social auth plugin, we don't need to created user accounts. But those users still need to get permissions, so this assigns them to the basic Newsroom Users group.

**Testing**
Miriam, who didn't have an account before on the test site, was kind enough to test this and confirm it worked as expected.