### PR TITLE
TECH-7750 tweak to unprompt

### DIFF
--- a/media/js/admin/sources/promptUnsavedChanges.js
+++ b/media/js/admin/sources/promptUnsavedChanges.js
@@ -32,8 +32,11 @@
   $(window).on("load", () => {
     setFormModifiedEvent();
 
-    $('.selector-chosen').bind("DOMSubtreeModified", () => {
-      formModified = true;
+    $('.selector-chosen').bind("DOMSubtreeModified", function () {
+      // This if is main to catch the scenario where the user just selects something with the 'from' list, but doesn't add the item.
+      if ($(this).children('option').length) {
+        formModified = true;
+      }
     });
 
     $('.add-row a').click(() => {

--- a/media/js/admin/sources/promptUnsavedChanges.js
+++ b/media/js/admin/sources/promptUnsavedChanges.js
@@ -9,8 +9,8 @@
     const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
     const originalSet = descriptor.set;
 
-    // define our own setter
-    descriptor.set = (val) => {
+    // define our own setter. This needs to be a regular function so that `this` is the input field rather than the window
+    descriptor.set = function() {
       if ($(this).attr('name').includes('date_time')) {
         formModified = true;
       }
@@ -20,18 +20,18 @@
     Object.defineProperty(HTMLInputElement.prototype, "value", descriptor);
   }
 
+  customInputSetter();
+
   function setFormModifiedEvent() {
     $(':input:not(:button,:submit), textarea').on('input', () => {
       formModified = true;
     });
   }
 
-  // Initial Setup
-  customInputSetter();
-  setFormModifiedEvent();
-
   // The selector-chosen fields are inline and aren't available even if the document is ready, so need to wait until the load event
   $(window).on("load", () => {
+    setFormModifiedEvent();
+
     $('.selector-chosen').bind("DOMSubtreeModified", () => {
       formModified = true;
     });
@@ -41,9 +41,11 @@
     });
 
     // Don't warn user they have unsaved changes if they click save
-    $('input:submit').click(() => {
-      formModified = false;
-      saveClicked = true;
+    $('input:submit').click((evt) => {
+      if (evt.target.value.toLowerCase().includes('save')) {
+        formModified = false;
+        saveClicked = true;
+      }
     });
   });
 

--- a/media/js/admin/sources/promptUnsavedChanges.js
+++ b/media/js/admin/sources/promptUnsavedChanges.js
@@ -17,7 +17,7 @@
       originalSet.apply(this, arguments);
     };
 
-    Object.defineProperty(HTMLInputElement.prototype, "value", descriptor);
+    Object.defineProperty(HTMLInputElement.prototype, 'value', descriptor);
   }
 
   customInputSetter();
@@ -29,10 +29,10 @@
   }
 
   // The selector-chosen fields are inline and aren't available even if the document is ready, so need to wait until the load event
-  $(window).on("load", () => {
+  $(window).on('load', () => {
     setFormModifiedEvent();
 
-    $('.selector-chosen').bind("DOMSubtreeModified", function () {
+    $('.selector-chosen').bind('DOMSubtreeModified', function () {
       // This if is main to catch the scenario where the user just selects something with the 'from' list, but doesn't add the item.
       if ($(this).children('option').length) {
         formModified = true;


### PR DESCRIPTION
[TECH-7750 <name here>](https://industrydive.atlassian.net/browse/TECH-7750)

### Non-technical Context

### Technical Context
I mainly tested this for the `Add Source` page.

### Reproduction Steps

### Manual Testing Instructions
- Things that don't prompt 
  - [x] Reloading the page when it's not touched doesn't create a prompt
  - [x] Adding a blank interaction
- Things that do prompt
  - [x] Typing something into a input field 
  - [ ] Typing something into a textarea
  - [x] Selecting something from a dropdown
  - [x] Adding/Removing something from a slector
  - [x] Using a date or time picker

### QA Checklist

#### Developer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
- [x] Ensure code is not overly inefficient
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [ ] ~Technical documentation~


#### Reviewer

- [ ] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline GitHub comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [ ] Devise edge cases to test the bug fix or feature being merged
- [ ] Make sure the code is clean and understandable
    - [ ] Ask for inline comments on unclear sections
- [ ] Ensure code is not overly inefficient
- [ ] Ensure documentation is understandable and accurate, including:
    - [ ] Code comments and doc strings
    - [ ] Technical documentation
