### PR TITLE
 TECH-7631 admin.py clean-up and make more DRY try 2

### DIFF
--- a/sources/admin.py
+++ b/sources/admin.py
@@ -95,6 +95,9 @@ class InteractionAdmin(admin.ModelAdmin):
         the object is None (doesn't exist yet), always return False (we don't need to hide anything).
 
         Returns True if we need to hide the notes, False if the user has permissions to see/edit the notes.
+
+        NOTE: this could be abstracted out, as it is virtually identical to _determine_whether_to_hide_contact_data
+        in PersonAdmin.
         """
         if not obj:
             return False
@@ -306,6 +309,9 @@ class PersonAdmin(admin.ModelAdmin):
         the object is None (doesn't exist yet), always return False (we don't need to hide anything).
 
         Returns True if we need to hide the data, False if the user has permissions to see/edit the data.
+
+        NOTE: this could be abstracted out, as it is virtually identical to _determine_whether_to_hide_notes
+        in InteractionAdmin.
         """
         if not obj:
             # If creating a new `Person`, give all permissions

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -285,7 +285,8 @@ class PersonAdmin(admin.ModelAdmin):
             prepend_contact_fields = [name + '_semiprivate_display' for name in prepend_contact_fields]
 
             # and add the display value to the readonly fields as well
-            self.readonly_fields = self.readonly_fields + prepend_contact_fields
+            # also, we don't want the user to be able to change the privacy level if they can't see the contact details
+            self.readonly_fields = self.readonly_fields + prepend_contact_fields + ['privacy_level']
 
         current_contact_fields = prepend_contact_fields + default_contact_fields
 

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -278,7 +278,6 @@ class PersonAdmin(admin.ModelAdmin):
             'phone_number_primary',
             'phone_number_secondary',
         ]
-        # hide_contact_data=1
 
         if hide_contact_data:
             # set the semiprivate fields to the display value

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -267,7 +267,11 @@ class PersonAdmin(admin.ModelAdmin):
         # hide_contact_data=1
 
         if hide_contact_data:
+            # set the semiprivate fields to the display value
             prepend_contact_fields = [name + '_semiprivate_display' for name in prepend_contact_fields]
+
+            # and add the display value to the readonly fields as well
+            self.readonly_fields = self.readonly_fields + prepend_contact_fields
 
         contact_dict = {'fields': prepend_contact_fields + default_contact_fields}
 
@@ -308,15 +312,6 @@ class PersonAdmin(admin.ModelAdmin):
                 ),
             }),
         )
-        # self.readonly_fields = [
-        #     'created_by',
-        #     'entry_method',
-        #     'entry_type',
-        #     'email_address_semiprivate_display',   #diff
-        #     'phone_number_primary_semiprivate_display', #diff
-        #     'phone_number_secondary_semiprivate_display', #diff
-        #     'updated',
-        # ]
 
     def add_view(self, *args, **kwargs):
         self._set_fieldsets(hide_contact_data=False)
@@ -329,26 +324,12 @@ class PersonAdmin(admin.ModelAdmin):
         notes field for them
         """
         obj = Person.objects.get(id=object_id)
+
         if obj.privacy_level == 'searchable' and obj.created_by != request.user:
             self._set_fieldsets(hide_contact_data=True)
-
-            self.readonly_fields = [
-                'created_by',
-                'entry_method',
-                'entry_type',
-                'email_address_semiprivate_display',
-                'phone_number_primary_semiprivate_display',
-                'phone_number_secondary_semiprivate_display',
-                'updated',
-            ]
         else:
             self._set_fieldsets(hide_contact_data=False)
-            self.readonly_fields = [
-                'created_by',
-                'entry_method',
-                'entry_type',
-                'updated',
-            ]
+
         return self.changeform_view(request, object_id, form_url, extra_context)
 
 

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -308,10 +308,6 @@ class PersonAdmin(admin.ModelAdmin):
                 ),
             }),
         )
-
-    # def add_view(self, *args, **kwargs):
-    #     self._set_fieldsets(hide_contact_data=False)
-    #     super(PersonAdmin, self).add_view(*args, **kwargs)
         # self.readonly_fields = [
         #     'created_by',
         #     'entry_method',
@@ -321,6 +317,10 @@ class PersonAdmin(admin.ModelAdmin):
         #     'phone_number_secondary_semiprivate_display', #diff
         #     'updated',
         # ]
+
+    def add_view(self, *args, **kwargs):
+        self._set_fieldsets(hide_contact_data=False)
+        return super(PersonAdmin, self).add_view(*args, **kwargs)
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         """

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -227,7 +227,7 @@ class PersonAdmin(admin.ModelAdmin):
     list_filter = [IndustryFilter, ExpertiseFilter, OrganizationFilter, 'timezone', 'city', 'state', 'privacy_level']
     search_fields = ['city', 'country', 'email_address', 'expertise__name', 'first_name', 'language', 'name', 'notes', 'organization', 'state', 'title', 'type_of_expert', 'twitter', 'website']
     filter_horizontal = ['expertise', 'industries', 'organization']
-    readonly_fields = ['entry_method', 'entry_type', 'created_by']
+    readonly_fields = ['entry_method', 'entry_type', 'created_by', 'updated']
     # save_as = True
     save_on_top = True
     view_on_site = False  # THIS DOES NOT WORK CURRENTLY
@@ -252,6 +252,76 @@ class PersonAdmin(admin.ModelAdmin):
     phone_number_secondary_semiprivate_display.short_description = 'Phone number secondary'
 
 
+    def _set_fieldsets(self, hide_contact_data=False):
+        default_contact_fields = [
+            'linkedin',
+            'twitter',
+            'skype',
+        ]
+
+        prepend_contact_fields = [
+            'email_address',
+            'phone_number_primary',
+            'phone_number_secondary',
+        ]
+        # hide_contact_data=1
+
+        if hide_contact_data:
+            prepend_contact_fields = [name + '_semiprivate_display' for name in prepend_contact_fields]
+
+        contact_dict = {'fields': prepend_contact_fields + default_contact_fields}
+
+        self.fieldsets = (
+            ('Privacy', {
+                'fields': ('privacy_level',)
+            }),
+            ('General info', {
+                'fields': (
+                    'prefix',
+                    'pronouns',
+                    'name',
+                    'title',
+                    'industries',
+                    'organization',
+                    'website',
+                    'type_of_expert',
+                    'expertise',
+                ),
+            }),
+            ('Contact info', contact_dict),
+            ('Location info', {
+                'fields': (
+                    'timezone',
+                    'city',
+                    'state',
+                    'country',
+                ),
+            }),
+            ('Advanced info', {
+                'classes': ('collapse',),
+                'fields': (
+                    'entry_method',
+                    'entry_type',
+                    'created_by',
+                    # 'last_updated_by',
+                    'updated',
+                ),
+            }),
+        )
+        self.readonly_fields = [
+            'created_by',
+            'entry_method',
+            'entry_type',
+            'email_address_semiprivate_display',   #diff
+            'phone_number_primary_semiprivate_display', #diff
+            'phone_number_secondary_semiprivate_display', #diff
+            'updated',
+        ]
+
+    # def add_view(self, *args, **kwargs):
+    #     self._set_fieldsets(hide_contact_data=False)
+    #     super(PersonAdmin, self).add_view(*args, **kwargs)
+
     def change_view(self, request, object_id, form_url='', extra_context=None):
         """
         If the privacy level is semi-private/searchable and the logged
@@ -260,52 +330,8 @@ class PersonAdmin(admin.ModelAdmin):
         """
         obj = Person.objects.get(id=object_id)
         if obj.privacy_level == 'searchable' and obj.created_by != request.user:
-            self.fieldsets = (
-                ('Privacy', {
-                    'fields': ('privacy_level',)
-                }),
-                ('General info', {
-                    'fields': (
-                        'prefix',
-                        'pronouns',
-                        'name',
-                        'title',
-                        'industries',
-                        'organization',
-                        'website',
-                        'type_of_expert',
-                        'expertise',
-                    ),
-                }),
-                ('Contact info', {
-                    'fields': (
-                        'email_address_semiprivate_display',
-                        'phone_number_primary_semiprivate_display',
-                        'phone_number_secondary_semiprivate_display',
-                        'linkedin',
-                        'twitter',
-                        'skype',
-                    ),
-                }),
-                ('Location info', {
-                    'fields': (
-                        'timezone',
-                        'city',
-                        'state',
-                        'country',
-                    ),
-                }),
-                ('Advanced info', {
-                    'classes': ('collapse',),
-                    'fields': (
-                        'entry_method',
-                        'entry_type',
-                        'created_by',
-                        # 'last_updated_by',
-                        'updated',
-                    ),
-                }),
-            )
+            self._set_fieldsets(hide_contact_data=True)
+
             self.readonly_fields = [
                 'created_by',
                 'entry_method',
@@ -316,52 +342,7 @@ class PersonAdmin(admin.ModelAdmin):
                 'updated',
             ]
         else:
-            self.fieldsets = (
-                ('Privacy', {
-                    'fields': ('privacy_level',)
-                }),
-                ('General info', {
-                    'fields': (
-                        'prefix',
-                        'pronouns',
-                        'name',
-                        'title',
-                        'industries',
-                        'organization',
-                        'website',
-                        'type_of_expert',
-                        'expertise',
-                    ),
-                }),
-                ('Contact info', {
-                    'fields': (
-                        'email_address',
-                        'phone_number_primary',
-                        'phone_number_secondary',
-                        'linkedin',
-                        'twitter',
-                        'skype',
-                    ),
-                }),
-                ('Location info', {
-                    'fields': (
-                        'timezone',
-                        'city',
-                        'state',
-                        'country',
-                    ),
-                }),
-                ('Advanced info', {
-                    'classes': ('collapse',),
-                    'fields': (
-                        'entry_method',
-                        'entry_type',
-                        'created_by',
-                        # 'last_updated_by',
-                        'updated',
-                    ),
-                }),
-            )
+            self._set_fieldsets(hide_contact_data=False)
             self.readonly_fields = [
                 'created_by',
                 'entry_method',

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -308,19 +308,19 @@ class PersonAdmin(admin.ModelAdmin):
                 ),
             }),
         )
-        self.readonly_fields = [
-            'created_by',
-            'entry_method',
-            'entry_type',
-            'email_address_semiprivate_display',   #diff
-            'phone_number_primary_semiprivate_display', #diff
-            'phone_number_secondary_semiprivate_display', #diff
-            'updated',
-        ]
 
     # def add_view(self, *args, **kwargs):
     #     self._set_fieldsets(hide_contact_data=False)
     #     super(PersonAdmin, self).add_view(*args, **kwargs)
+        # self.readonly_fields = [
+        #     'created_by',
+        #     'entry_method',
+        #     'entry_type',
+        #     'email_address_semiprivate_display',   #diff
+        #     'phone_number_primary_semiprivate_display', #diff
+        #     'phone_number_secondary_semiprivate_display', #diff
+        #     'updated',
+        # ]
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         """
@@ -366,10 +366,10 @@ class PersonAdmin(admin.ModelAdmin):
 
 
     def get_readonly_fields(self, request, obj=None):
-        if self.fieldsets and 'edit' not in request.GET:
-            return flatten_fieldsets(self.fieldsets)
-        elif 'add' in request.GET:
+        if '/add/' in request.path:
             return self.readonly_fields
+        elif 'edit' not in request.GET:
+            return flatten_fieldsets(self.fieldsets)
         else:
             return self.readonly_fields
 

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -285,35 +285,6 @@ class PersonAdmin(admin.ModelAdmin):
             return prepend_contact_fields
 
 
-    def get_fieldsets(self, request, obj=None):
-
-        # cover the one weird edge case
-        if obj and obj.created_by != request.user and obj.privacy_level == 'private_individual':
-            return [(None, {'fields': []})]
-        else:
-            hide_contact_data = self._determine_whether_to_hide_contact_data(request, obj)
-            return self._return_fieldsets(hide_contact_data=hide_contact_data)
-        # if not obj:
-        #     return self._return_fieldsets(hide_contact_data=False)
-        # elif obj.created_by == request.user:
-        #     return self._return_fieldsets(hide_contact_data=False)
-        # elif obj.privacy_level == 'private_individual':
-        # elif obj.privacy_level == 'searchable':
-        #     return self._return_fieldsets(hide_contact_data=True)
-        # else:
-        #     return self._return_fieldsets(hide_contact_data=False)
-
-        # super(PersonAdmin, self).get_fieldsets()
-        # import pdb; pdb.set_trace()
-        # if obj.created_by == request.user:
-        #     self._set_fieldsets(hide_contact_data=False, privacy_readonly=False)
-        # elif obj.privacy_level == 'private_individual':
-        #     self.fieldsets = ()
-        # elif obj.privacy_level == 'searchable':
-        #     self._set_fieldsets(hide_contact_data=True, privacy_readonly=True)
-        # else:
-        #     self._set_fieldsets(hide_contact_data=False, privacy_readonly=False)
-
     def _determine_whether_to_hide_contact_data(self, request, obj):
         if not obj:
             return False
@@ -389,27 +360,6 @@ class PersonAdmin(admin.ModelAdmin):
             }),
         )
 
-    # def change_view(self, request, object_id, form_url='', extra_context=None):
-    #     """
-    #     Allow the correct editors to set the correct fields.
-    #     """
-        # obj = Person.objects.get(id=object_id)
-
-        # If the Source was created by the user, allow all editing. If the Source was
-        # created by somoone else and is private, show nothing. If the Source was created
-        # by someone else and is semiprivate, don't show/allow ediiting the contact fields,
-        # and don't let the user change the privacy field. In all other cases, allow all editing.
-        # if obj.created_by == request.user:
-        #     self._set_fieldsets(hide_contact_data=False, privacy_readonly=False)
-        # elif obj.privacy_level == 'private_individual':
-        #     self.fieldsets = ()
-        # elif obj.privacy_level == 'searchable':
-        #     self._set_fieldsets(hide_contact_data=True, privacy_readonly=True)
-        # else:
-        #     self._set_fieldsets(hide_contact_data=False, privacy_readonly=False)
-
-        # return self.changeform_view(request, object_id, form_url, extra_context)
-
 
     def get_queryset(self, request):
         """ only show private sources to the person who created them """
@@ -424,13 +374,23 @@ class PersonAdmin(admin.ModelAdmin):
         )
 
 
+    def get_fieldsets(self, request, obj=None):
+
+        # cover the one weird edge case
+        if obj and obj.created_by != request.user and obj.privacy_level == 'private_individual':
+            return [(None, {'fields': []})]
+        else:
+            hide_contact_data = self._determine_whether_to_hide_contact_data(request, obj)
+            return self._return_fieldsets(hide_contact_data=hide_contact_data)
+
+
     def get_readonly_fields(self, request, obj=None):
         if not obj:
             return self.readonly_fields
-
+        # import pdb; pdb.set_trace()
         hide_contact_data = self._determine_whether_to_hide_contact_data(request, obj)
 
-        if '?edit=True' not in request.GET:
+        if 'edit' not in request.GET:
             current_fieldsets = self._return_fieldsets(hide_contact_data=hide_contact_data)
             return flatten_fieldsets(current_fieldsets)
         elif hide_contact_data:

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -108,7 +108,7 @@ class InteractionAdmin(admin.ModelAdmin):
         If the user doesn't have permission to see the notes, both the notes display and the
         privacy level are added to the default readonly fields.
 
-        Use Django's built in hook for accessing readonly fields. Manipulating self.readonly_fields
+        Use Django's built in hook for accessing readonly fields. NOTE: Manipulating self.readonly_fields
         directly leads to problems.
         """
         hide_data = self._determine_whether_to_hide_notes(request, obj)
@@ -122,7 +122,7 @@ class InteractionAdmin(admin.ModelAdmin):
         """
         If the user doesn't have permission to view the notes, display the replacement notes field instead.
 
-        Use Django's built in hook for accessing fields. Manipulating self.fields directly can lead to problems.
+        Use Django's built in hook for accessing fields. NOTE: Manipulating self.fields directly can lead to problems.
         """
         hide_data = self._determine_whether_to_hide_notes(request, obj)
         if hide_data:
@@ -311,14 +311,14 @@ class PersonAdmin(admin.ModelAdmin):
             # If creating a new `Person`, give all permissions
             return False
         elif obj.created_by == request.user:
-            # users can always see their own `Person`s
+            # Users can always see their own `Person`s
             return False
         elif obj.privacy_level in ['searchable', 'private_individual']:
-            # if the `Person` is at all private, and the user didn't create the
+            # If the `Person` is at all private, and the user didn't create the
             # object, don't allow viewing of contact data
             return True
         else:
-            # only reach here for public `Person`s created by a different user
+            # Only reach here for public `Person`s created by a different user
             return False
 
 
@@ -405,11 +405,11 @@ class PersonAdmin(admin.ModelAdmin):
         """
 
         if obj and obj.created_by != request.user and obj.privacy_level == 'private_individual':
-            # cover the one weird edge case not covered by `_determine_whether_to_hide_contact_data`
-            # this is if the user is trying to view a person they're not even allowed to know exists
+            # Cover the one weird edge case not covered by `_determine_whether_to_hide_contact_data`
+            # This is if the user is trying to view a person they're not even allowed to know exists
             return [(None, {'fields': []})]
         else:
-            # construct the correct fieldsets based on permissions
+            # Construct the correct fieldsets based on permissions
             hide_contact_data = self._determine_whether_to_hide_contact_data(request, obj)
             return self._return_fieldsets(hide_contact_data=hide_contact_data)
 
@@ -420,23 +420,23 @@ class PersonAdmin(admin.ModelAdmin):
         directly leads to problems.
         """
         if not obj:
-            # if creating the obj, use only default readonly fields
+            # If creating the obj, use only default readonly fields
             return self.readonly_fields
 
         hide_contact_data = self._determine_whether_to_hide_contact_data(request, obj)
 
         if 'edit' not in request.GET:
-            # if we're not editing, all fields should be readonly
-            # use _return_fieldsets to get the correct fields for this permission level
+            # If we're not editing, all fields should be readonly
+            # Use _return_fieldsets to get the correct fields for this permission level
             current_fieldsets = self._return_fieldsets(hide_contact_data=hide_contact_data)
             return flatten_fieldsets(current_fieldsets)
         elif hide_contact_data:
-            # if we're editing,, and data is hidden from the user, we want the contact data to be readonly
-            # we also want the privacy level field to be readonly
+            # If we're editing, and data is hidden from the user, we want the contact data to be readonly
+            # We also want the privacy level field to be readonly
             contact_fields_to_add = self._get_correct_contact_field_names(hide_contact_data=hide_contact_data)
             return self.readonly_fields + ['privacy_level'] + contact_fields_to_add
         else:
-            # if we're editing AND the user has permissions, use the default fields
+            # If we're editing AND the user has permissions, use the default fields
             return self.readonly_fields
 
 

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -253,6 +253,20 @@ class PersonAdmin(admin.ModelAdmin):
 
 
     def _set_fieldsets(self, hide_contact_data=False):
+        """
+        Sets `self.fieldsets`. This needs to be explicitly called every view that should have fieldsets,
+        because the contact info fieldset will have different fields depending on if we want to show or
+        hide the private contact data.
+
+        This could be considerably more abstract and thus complicated, it could change fieldsets
+        besides the contact info. I decided to shy away from that right now -- we can always come
+        back and change it, by eg passing in a dict with keys of the fieldsets and values of the
+        additions, possibly in both pre- and append flavors.
+
+        Arguments:
+            hide_contact_data - if True, replace the email & phone fields with the semiprivate display values, as well
+                as setting the readonly fields to include these fields.
+        """
         default_contact_fields = [
             'linkedin',
             'twitter',
@@ -273,7 +287,7 @@ class PersonAdmin(admin.ModelAdmin):
             # and add the display value to the readonly fields as well
             self.readonly_fields = self.readonly_fields + prepend_contact_fields
 
-        contact_dict = {'fields': prepend_contact_fields + default_contact_fields}
+        current_contact_fields = prepend_contact_fields + default_contact_fields
 
         self.fieldsets = (
             ('Privacy', {
@@ -292,7 +306,9 @@ class PersonAdmin(admin.ModelAdmin):
                     'expertise',
                 ),
             }),
-            ('Contact info', contact_dict),
+            ('Contact info', {
+                'fields': current_contact_fields
+            }),
             ('Location info', {
                 'fields': (
                     'timezone',

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -224,7 +224,7 @@ class OrganizationFilter(SimpleListFilter):
 
 class PersonAdmin(admin.ModelAdmin):
     list_display = ['name', 'updated', 'created_by', 'privacy_level']
-    list_filter = [IndustryFilter, ExpertiseFilter, OrganizationFilter, 'timezone', 'city', 'state', 'privacy_level']
+    list_filter = [IndustryFilter, ExpertiseFilter, OrganizationFilter, 'city', 'state', 'privacy_level']
     search_fields = ['city', 'country', 'email_address', 'expertise__name', 'first_name', 'language', 'name', 'notes', 'organization', 'state', 'title', 'type_of_expert', 'twitter', 'website']
     filter_horizontal = ['expertise', 'industries', 'organization']
     readonly_fields = ['entry_method', 'entry_type', 'created_by', 'updated']

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -92,13 +92,19 @@ class InteractionAdmin(admin.ModelAdmin):
         notes field for them
         """
         obj = Interaction.objects.get(id=object_id)
-        # base_fields = ['privacy_level', ]
+
+        base_readonly_fields = ['created_by']
+
+        # always want these fields, no matter how we show the notes
+        fields_before_notes = ['privacy_level', 'date_time', 'interaction_type', 'interviewee', 'interviewer']
+        fields_after_notes = ['created_by']
+
         if obj.privacy_level == 'searchable' and obj.created_by != request.user:
-            self.fields = ['privacy_level', 'date_time', 'interaction_type', 'interviewee', 'interviewer', 'notes_semiprivate_display', 'created_by']
-            self.readonly_fields = ['created_by', 'privacy_level', 'notes_semiprivate_display']
+            self.fields = fields_before_notes + ['notes_semiprivate_display'] + fields_after_notes
+            self.readonly_fields = base_readonly_fields + ['privacy_level', 'notes_semiprivate_display']
         else:
-            self.fields = ['privacy_level', 'date_time', 'interaction_type', 'interviewee', 'interviewer', 'notes', 'created_by']
-            self.readonly_fields = ['created_by']
+            self.fields = fields_before_notes + ['notes'] + fields_after_notes
+            self.readonly_fields = base_readonly_fields
         return self.changeform_view(request, object_id, form_url, extra_context)
 
 

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -410,6 +410,8 @@ class PersonAdmin(admin.ModelAdmin):
         leads to problems.
         """
 
+        # TODO: we may able to delete this if statement, as we believe the first case is covered
+        # by the queryset restrictions
         if obj and obj.created_by != request.user and obj.privacy_level == 'private_individual':
             # Cover the one weird edge case not covered by `_determine_whether_to_hide_contact_data`
             # This is if the user is trying to view a person they're not even allowed to know exists


### PR DESCRIPTION
[TECH-7631 cleanup admin.py and make it more DRY](https://industrydive.atlassian.net/browse/TECH-7631) -- I also fixed the bug where fieldsets were not appearing on the add page, and changed the privacy field to readonly in many cases. 

### Non-technical Context
Removed a workaround where you could change a semiprivate person to public and therefore expose their details. Cleaned up add page.

### Technical Context
There was a lot of duplicated code, and manipulating the readonly fields in particular causes problems. I pulled things out into the `get_fields`, `get_fieldsets` and `get_readonly_fields` hooks that django wants you to use.

### Manual Testing Instructions

Have 2 normal users. Log in as 1 of them and create 3 sources, one of each privacy level. The add page should be organized. Now view each source, and edit as well. You should see all the data, and everything except the default readonly fields should be editable.

Log in as the 2nd person. You should only see 2 of the suorces. View both. The appropriate fields should be hidden. Edit both. You should not be able to change the hidden fields or the privacy level of the semi private source.  

Create a semiprivate interaction as user1. You should be able to edit it. As user2, view it (you should not see the notes) and edit it (you should not be able to edit the privacy level OR the notes themselves).


### QA Checklist

#### Developer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- <s>Devise edge cases to test the bug fix or feature being merged</s> DECIDED NOT TO IN CONSULTATION WITH @greglinch 
- [x] Make sure the code is clean and understandable
- [x] Ensure code is not overly inefficient
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [N/A] Technical documentation


#### Reviewer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline GitHub comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
    - [x] Ask for inline comments on unclear sections
- [x] Ensure code is not overly inefficient
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [na] Technical documentation
