### PR TITLE
TECH-7764 change user fields to use full name

### DIFF
--- a/sources/admin.py
+++ b/sources/admin.py
@@ -75,10 +75,14 @@ class InteractionInline(admin.TabularInline):
         )
 
     def interviewers_listview(self, obj):
-        return InteractionAdmin.interviewers_listview(self, obj)
+        return InteractionAdmin.interviewers_listview(None, obj)
     interviewers_listview.short_description = 'Interviewer(s)'
 
 class InterviewerChoiceField(ModelMultipleChoiceField):
+    """
+        This will change how the interviewer is displayed inside the dropdowns
+        It will now show the user's full name instead of the user's username
+    """
     def label_from_instance(self, obj):
         return obj.get_full_name()
 
@@ -175,6 +179,10 @@ class InteractionAdmin(admin.ModelAdmin):
         super(InteractionAdmin, self).save_model(request, obj, form, change)
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):
+        """
+            Overwrites formfield_for_manytomany is db field is interviewer.
+            Allows us to display user's full name in select dropdowns
+        """
         if db_field.name == 'interviewer':
             return InterviewerChoiceField(queryset=User.objects.all(), widget=FilteredSelectMultiple('interviewer', is_stacked=False))
         return super().formfield_for_manytomany(db_field, request, **kwargs)

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -19,7 +19,7 @@ from sources.models import (
 )
 
 
-def get_username(obj):
+def get_user_display_name(obj):
     return obj.get_full_name() or obj.username
 
 class UserChoiceField(ModelMultipleChoiceField):
@@ -29,7 +29,7 @@ class UserChoiceField(ModelMultipleChoiceField):
         instead of the user's username.
     """
     def label_from_instance(self, obj):
-        return get_username(obj)
+        return get_user_display_name(obj)
 
 class DiveAdmin(admin.ModelAdmin):
     fields = ['name', 'users']
@@ -205,12 +205,12 @@ class InteractionAdmin(admin.ModelAdmin):
             This will display a custom created_by field by using
             the user's first and last name instead of the user's username
         """
-        return get_username(obj.created_by)
+        return get_user_display_name(obj.created_by)
     get_created_by.short_description = 'Created By'
 
     def interviewers_listview(self, obj):
         interviewers_list = obj.interviewer.all()
-        interviewers = [get_username(interviewer) for interviewer in interviewers_list]
+        interviewers = [get_user_display_name(interviewer) for interviewer in interviewers_list]
         return ', '.join(interviewers)
     interviewers_listview.short_description = 'Interviewer(s)'
 
@@ -530,7 +530,7 @@ class PersonAdmin(admin.ModelAdmin):
             This will display a custom created_by field by using
             the user's first and last name instead of the user's username
         """
-        return get_username(obj.created_by)
+        return get_user_display_name(obj.created_by)
     get_created_by.short_description = 'Created By'
 
 

--- a/sources/admin.py
+++ b/sources/admin.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from django.contrib.admin.filters import SimpleListFilter
 from django.contrib.admin.utils import flatten_fieldsets
+from django.contrib.admin.widgets import FilteredSelectMultiple
+from django.contrib.auth.models import User
 from django.db.models import Q
+from django.forms import ModelMultipleChoiceField
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import format_html
@@ -40,7 +43,7 @@ class IndustryAdmin(admin.ModelAdmin):
 class InteractionInline(admin.TabularInline):
     model = Interaction
     # the fields are listed explicity to avoid showing notes, which can't be easily displayed like the other hidden field values
-    fields = ['privacy_level', 'date_time', 'interaction_type', 'interviewee', 'interviewer', 'created_by', 'notes_view']
+    fields = ['privacy_level', 'date_time', 'interaction_type', 'interviewee', 'interviewers_listview', 'created_by', 'notes_view']
 
     max_num = 0
     readonly_fields = fields  # ['notes_semiprivate']
@@ -71,6 +74,13 @@ class InteractionInline(admin.TabularInline):
             Q(created_by=request.user, privacy_level='private_individual')
         )
 
+    def interviewers_listview(self, obj):
+        return InteractionAdmin.interviewers_listview(self, obj)
+    interviewers_listview.short_description = 'Interviewer(s)'
+
+class InterviewerChoiceField(ModelMultipleChoiceField):
+    def label_from_instance(self, obj):
+        return obj.get_full_name()
 
 class InteractionNewInline(admin.TabularInline):
     model = Interaction
@@ -86,15 +96,17 @@ class InteractionNewInline(admin.TabularInline):
 
         return qs.none()
 
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        return InteractionAdmin.formfield_for_manytomany(self, db_field, request, **kwargs)
 
 class InteractionAdmin(admin.ModelAdmin):
-    list_display = ['interviewee', 'interaction_type', 'date_time', 'created_by', 'interviewers_listview', 'privacy_level']
+    list_display = ['interviewee', 'interaction_type', 'date_time', 'get_created_by', 'interviewers_listview', 'privacy_level']
     list_filter = ['interaction_type']
-    filter_horizontal = ['interviewer']
+    #filter_horizontal = ['interviewer']
 
-    _fields_always_readonly = ['created_by']
+    _fields_always_readonly = ['get_created_by']
     _fields_before_notes = ['privacy_level', 'date_time', 'interaction_type', 'interviewee', 'interviewer']
-    _fields_after_notes = ['created_by']
+    _fields_after_notes = ['get_created_by']
 
 
     def _determine_whether_to_hide_notes(self, request, obj):
@@ -126,7 +138,7 @@ class InteractionAdmin(admin.ModelAdmin):
         if hide_data:
             return self._fields_always_readonly + ['notes_semiprivate_display', 'privacy_level']
         else:
-            return self._fields_always_readonly   
+            return self._fields_always_readonly
 
 
     def get_fields(self, request, obj=None):
@@ -162,10 +174,22 @@ class InteractionAdmin(admin.ModelAdmin):
         ## save
         super(InteractionAdmin, self).save_model(request, obj, form, change)
 
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        if db_field.name == 'interviewer':
+            return InterviewerChoiceField(queryset=User.objects.all(), widget=FilteredSelectMultiple('interviewer', is_stacked=False))
+        return super().formfield_for_manytomany(db_field, request, **kwargs)
+
+    def get_created_by(self, obj):
+        """
+            This will display a custom created_by field by using
+            the user's first and last name instead of the user's username
+        """
+        return obj.created_by.get_full_name()
+    get_created_by.short_description = 'Created By'
 
     def interviewers_listview(self, obj):
         interviewers_list = obj.interviewer.all()
-        interviewers = [interviewer.username for interviewer in interviewers_list]
+        interviewers = [interviewer.get_full_name() for interviewer in interviewers_list]
         return ', '.join(interviewers)
     interviewers_listview.short_description = 'Interviewer(s)'
 
@@ -181,7 +205,7 @@ class OrganizationAdmin(admin.ModelAdmin):
     list_display = ['name']
     search_fields = ['name']
 
-    
+
 # for SimpleListFilter classes
 all_sources = Person.objects.all()
 private_sources = all_sources.filter(privacy_level='private_individual')
@@ -263,11 +287,11 @@ class OrganizationFilter(SimpleListFilter):
 
 
 class PersonAdmin(admin.ModelAdmin):
-    list_display = ['name', 'updated', 'created_by', 'privacy_level']
+    list_display = ['name', 'updated', 'get_created_by', 'privacy_level']
     list_filter = [IndustryFilter, ExpertiseFilter, OrganizationFilter, 'city', 'state', 'privacy_level', 'gatekeeper']
     search_fields = ['city', 'country', 'email_address', 'expertise__name', 'first_name', 'language', 'name', 'notes', 'organization', 'state', 'title', 'type_of_expert', 'twitter', 'website']
     filter_horizontal = ['expertise', 'industries', 'organization', 'exportable_by']
-    readonly_fields = ['entry_method', 'entry_type', 'created_by', 'updated']
+    readonly_fields = ['entry_method', 'entry_type', 'get_created_by', 'updated']
     # save_as = True
     save_on_top = True
     view_on_site = False  # THIS DOES NOT WORK CURRENTLY
@@ -393,7 +417,7 @@ class PersonAdmin(admin.ModelAdmin):
                     'exportable_by',
                     'entry_method',
                     'entry_type',
-                    'created_by',
+                    'get_created_by',
                     # 'last_updated_by',
                     'updated',
                 ),
@@ -479,6 +503,14 @@ class PersonAdmin(admin.ModelAdmin):
 
         ## save
         super(PersonAdmin, self).save_model(request, obj, form, change)
+
+    def get_created_by(self, obj):
+        """
+            This will display a custom created_by field by using
+            the user's first and last name instead of the user's username
+        """
+        return obj.created_by.get_full_name()
+    get_created_by.short_description = 'Created By'
 
 
 admin.site.register(Dive, DiveAdmin)


### PR DESCRIPTION
[TECH-7764 change user fields to use full name](https://industrydive.atlassian.net/browse/TECH-7764)

### Non-technical Context

This merge will displayed the User's first and last name in the Interaction and Sources Admin instead of the User's username.

### Technical Context

- Create custom admin methods for displaying created by field. 
- Change interviewers_listview to use full name. 
- Overwrite form field for many to many method in Interaction Admin.
- Create InterviewerChoice class to overwrite label from instance to display user's full name.

### Reproduction Steps

- [x] Login to admin for sourcedive.
- [x] Go to source list view. Created by column should display username.
- [x] Go to sources change page and open advanced info. Created by field should display username. Also attempt to add a new interaction on the same page below. Interviewer selects should display username.
- [x] Go to interaction list view. Created by and interviewer(s) column should display username.
- [x] Go to interaction add page. Select dropdown for interviewer(s) should display username.
- [x] Go to interaction change page. Repeat above step. Created by field should also display username.

### Manual Testing Instructions

Repeat the reproduction steps, except User's first and last name should appear instead of user' s username.

- [x] Login to admin for sourcedive.
- [x] Go to source list view. Created by column should display user's first and last name.
- [x] Go to sources change page and open advanced info. Created by field should display user's first and last name. Also attempt to add a new interaction on the same page below. Interviewer selects should display user's first and last name.
- [x] Go to interaction list view. Created by and interviewer(s) column should display user's first and last name.
- [x] Go to interaction add page. Select dropdown for interviewer(s) should display user's first and last name.
- [x] Go to interaction change page. Repeat above step. Created by field should also display user's first and last name.
- [x] Go to Dive add and change pages. User select forms should display user's first name and last name.
- [x] If user doesn't have name, form will display username as a default


### QA Checklist

#### Developer

- [X] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [X] Devise edge cases to test the bug fix or feature being merged
- [X] Make sure the code is clean and understandable
- [X] Ensure code is not overly inefficient
- [X] Ensure documentation is understandable and accurate, including:
    - [X] Code comments and doc strings
    - [X] Technical documentation


#### Reviewer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline GitHub comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
    - [x] Ask for inline comments on unclear sections
- [x] Ensure code is not overly inefficient
- [x] Ensure documentation is understandable and accurate, including:
    - [x] Code comments and doc strings
    - [na] Technical documentation
