### PR TITLE
default created by in interaction inline

### DIFF
--- a/sources/admin.py
+++ b/sources/admin.py
@@ -130,7 +130,7 @@ class InteractionNewInline(admin.TabularInline, CreatedByMixin):
             a class in the select widget to enforce the correct dropdown
         """
         if db_field.name == 'created_by':
-            return UserChoiceField(queryset=User.objects.all(), widget=Select(attrs={'class': 'select'}))
+            return UserChoiceField(queryset=User.objects.all(), widget=Select(attrs={'class': 'select'}), initial=request.user.id)
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):


### PR DESCRIPTION
[TECH-8199 <name here>](https://industrydive.atlassian.net/browse/TECH-8199)

### Non-technical Context

Default the Interaction Inline Created By Dropdown to the Current User.

### Technical Context

Add an initial parameter to the form.

### Manual Testing Instructions

- [x] Go to the sources admin and select a source to change or add
- [x] Go to the "New Interaction" section and look at the created by dropdown
- [x] The dropdown should be defaulted to YOU (the current user)

### QA Checklist

#### Developer

- [X] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [X] Devise edge cases to test the bug fix or feature being merged
- [X] Make sure the code is clean and understandable
- [X] Ensure code is not overly inefficient
- [N/A] Ensure documentation is understandable and accurate, including:
    - [na] Code comments and doc strings
    - [na] Technical documentation


#### Reviewer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline GitHub comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
    - [na] Ask for inline comments on unclear sections
- [x] Ensure code is not overly inefficient
- [ ] Ensure documentation is understandable and accurate, including:
    - [na] Code comments and doc strings
    - [na] Technical documentation
