### PR TITLE
move python to 3.8, upgrade psycopg to 2.84

### DIFF
--- a/build/app/Dockerfile
+++ b/build/app/Dockerfile
@@ -1,5 +1,5 @@
 # You can use a specific version too, like python:3.6.5-alpine3.7
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 WORKDIR /usr/src/app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ future==0.16.0
 idna==2.5
 oauthlib==2.0.2
 pipi==1.0.1
-psycopg2==2.7.3.1
+psycopg2==2.8.4
 pyasn1==0.4.8
 pycryptodomex==3.4.6
 pyjwkest==1.3.6


### PR DESCRIPTION
[TECH-7630 <name here>](https://industrydive.atlassian.net/browse/TECH-7630)

### Non-technical Context

None

### Technical Context

Upgrade Docker Image to Python 3.8
 - The upgrade required psycopg 2.84

I received an error building 3.8

![Screen Shot 2020-05-29 at 12 45 34 PM](https://user-images.githubusercontent.com/22512686/83284144-502f2280-a1aa-11ea-84ec-3f1080320123.png)

After doing some research, it seems that this was fixed 

https://github.com/psycopg/psycopg2/issues/854

### Reproduction Steps

### Manual Testing Instructions

- [x] Pull down the branch and 
- [x] run `docker-compose build` `docker-compose up`
- [x] Exec into the container and check the python version. It should be 3.8.3

### QA Checklist

#### Developer

- [X] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
- [X] Devise edge cases to test the bug fix or feature being merged
- [X] Make sure the code is clean and understandable
- [X] Ensure code is not overly inefficient
- [N/A] Ensure documentation is understandable and accurate, including:
    - [ ] Code comments and doc strings
    - [ ] Technical documentation


#### Reviewer

- [x] Ensure code complies with the [style guide](https://industrydive.atlassian.net/wiki/spaces/TECH/pages/639500407/Tech+Team+s+Style+Guides)
    - If there are few or minor issues, add inline GitHub comments
    - If there are many issues or it seems like the developer did not follow the style guide, leave a comment asking them to do so
- [x] Devise edge cases to test the bug fix or feature being merged
- [x] Make sure the code is clean and understandable
    - [na] Ask for inline comments on unclear sections
- [x] Ensure code is not overly inefficient
- [na] Ensure documentation is understandable and accurate, including:
    - [na] Code comments and doc strings
    - [na] Technical documentation
